### PR TITLE
Mapping CWL types to OGC API Process Input elements

### DIFF
--- a/zoo_calrissian_runner/__init__.py
+++ b/zoo_calrissian_runner/__init__.py
@@ -225,20 +225,18 @@ class ZooInputs:
         for key, value in self.inputs.items():
             if "dataType" in value:
                 has_val=False
-                if value["dataType"]=="double":
+                if value["dataType"]=="double" or value["dataType"]=="float":
                     res[key]=float(value["value"])
                     has_val=True
-                if value["dataType"]=="integer":
+                elif value["dataType"]=="integer":
                     res[key]=int(value["value"])
                     has_val=True
-                if value["dataType"]=="boolean":
+                elif value["dataType"]=="boolean":
                     res[key]=bool(value["value"])
                     has_val=True
-                if not(has_val):
+                else:
                     res[key]=value["value"]
-        return res #{key: value["value"] for key, value in self.inputs.items()}
-
-        return {key: value["value"] for key, value in self.inputs.items()}
+        return res 
 
 
 class ZooOutputs:

--- a/zoo_calrissian_runner/__init__.py
+++ b/zoo_calrissian_runner/__init__.py
@@ -220,6 +220,24 @@ class ZooInputs:
 
     def get_processing_parameters(self):
         """Returns a list with the input parameters keys"""
+        res={}
+        hasVal=False;
+        for key, value in self.inputs.items():
+            if "dataType" in value:
+                has_val=False
+                if value["dataType"]=="double":
+                    res[key]=float(value["value"])
+                    has_val=True
+                if value["dataType"]=="integer":
+                    res[key]=int(value["value"])
+                    has_val=True
+                if value["dataType"]=="boolean":
+                    res[key]=bool(value["value"])
+                    has_val=True
+                if not(has_val):
+                    res[key]=value["value"]
+        return res #{key: value["value"] for key, value in self.inputs.items()}
+
         return {key: value["value"] for key, value in self.inputs.items()}
 
 

--- a/zoo_calrissian_runner/__init__.py
+++ b/zoo_calrissian_runner/__init__.py
@@ -224,18 +224,17 @@ class ZooInputs:
         hasVal=False;
         for key, value in self.inputs.items():
             if "dataType" in value:
-                has_val=False
-                if value["dataType"]=="double" or value["dataType"]=="float":
-                    res[key]=float(value["value"])
-                    has_val=True
-                elif value["dataType"]=="integer":
-                    res[key]=int(value["value"])
-                    has_val=True
-                elif value["dataType"]=="boolean":
-                    res[key]=bool(value["value"])
-                    has_val=True
-                else:
-                    res[key]=value["value"]
+                match value["dataType"]:
+                    case w if w in ["double","float"]:
+                        res[key]=float(value["value"])
+                    case "integer":
+                        res[key]=int(value["value"])
+                    case "boolean":
+                        res[key]=int(value["value"])
+                    case _:
+                        res[key]=value["value"]
+            else:
+                res[key]=value["value"]
         return res 
 
 


### PR DESCRIPTION
As described in Table 3 of the [BP 20-089r1](https://docs.ogc.org/bp/20-089r1.html#9-3-1-&nb;-single-cwl-type-parameter), this PR introduces new behavior for literal data (`boolean,` `int,` `long,` `float,` `double,` `string`) and complex data for CWL `File` type.

