### PR TITLE
Feature/access log status failed

### DIFF
--- a/zoo_calrissian_runner/__init__.py
+++ b/zoo_calrissian_runner/__init__.py
@@ -481,15 +481,15 @@ class ZooCalrissianRunner:
         self.update_status(progress=23, message="execution submitted")
 
         logger.info("execution")
-        execution = CalrissianExecution(job=job, runtime_context=session)
-        execution.submit()
+        self.execution = CalrissianExecution(job=job, runtime_context=session)
+        self.execution.submit()
 
-        execution.monitor(interval=self.monitor_interval)
+        self.execution.monitor(interval=self.monitor_interval)
 
-        if execution.is_complete():
+        if self.execution.is_complete():
             logger.info("execution complete")
 
-        if execution.is_succeeded():
+        if self.execution.is_succeeded():
             exit_value = zoo.SERVICE_SUCCEEDED
         else:
             exit_value = zoo.SERVICE_FAILED
@@ -497,10 +497,10 @@ class ZooCalrissianRunner:
         self.update_status(progress=90, message="delivering outputs, logs and usage report")
 
         logger.info("handle outputs execution logs")
-        output = execution.get_output()
-        log = execution.get_log()
-        usage_report = execution.get_usage_report()
-        tool_logs = execution.get_tool_logs()
+        output = self.execution.get_output()
+        log = self.execution.get_log()
+        usage_report = self.execution.get_usage_report()
+        tool_logs = self.execution.get_tool_logs()
 
         self.outputs.set_output(output)
 

--- a/zoo_calrissian_runner/__init__.py
+++ b/zoo_calrissian_runner/__init__.py
@@ -233,15 +233,14 @@ class ZooInputs:
                     import json
                     res[key]=value["value"]
                 else:
-                    match value["dataType"]:
-                        case w if w in ["double","float"]:
-                            res[key]=float(value["value"])
-                        case "integer":
-                            res[key]=int(value["value"])
-                        case "boolean":
-                            res[key]=int(value["value"])
-                        case _:
-                            res[key]=value["value"]
+                    if value["dataType"] in ["double","float"]:
+                        res[key]=float(value["value"])
+                    elif value["dataType"] == "integer":
+                        res[key]=int(value["value"])
+                    elif value["dataType"] == "boolean":
+                        res[key]=int(value["value"])
+                    else:
+                        res[key]=value["value"]
             else:
                 if "cache_file" in value:
                     print(value,file=sys.stderr)

--- a/zoo_calrissian_runner/__init__.py
+++ b/zoo_calrissian_runner/__init__.py
@@ -226,9 +226,7 @@ class ZooInputs:
         hasVal=False;
         for key, value in self.inputs.items():
             if "dataType" in value:
-                print(value,file=sys.stderr)
                 if isinstance(value["dataType"],list):
-                    print(value["value"],file=sys.stderr)
                     # How should we pass array for an input?
                     import json
                     res[key]=value["value"]
@@ -243,7 +241,6 @@ class ZooInputs:
                         res[key]=value["value"]
             else:
                 if "cache_file" in value:
-                    print(value,file=sys.stderr)
                     if "mimeType" in value:
                         res[key]={
                             "class": "File",


### PR DESCRIPTION
Remove `match` to enable the Python 3.8 support currently used in the ZOO-Project-DRU.

Add an `execution` attribute to access the `CalrissianExecution` at runtime. If anything goes wrong with the [`execute` method](https://github.com/EOEPCA/zoo-calrissian-runner/blob/feature/access-log-status-failed/zoo_calrissian_runner/__init__.py#L394-L533), this enables accessing the potential log files from a failed run.