### PR TITLE
Properly call the static method using the class name

### DIFF
--- a/zoo_calrissian_runner/__init__.py
+++ b/zoo_calrissian_runner/__init__.py
@@ -299,7 +299,7 @@ class ZooCalrissianRunner:
         self.monitor_interval = 30
         if "lenv" in self.zoo_conf.conf and "usid" in self.zoo_conf.conf["lenv"]:
             uuidString=self.zoo_conf.conf['lenv']['usid']
-            self._namespace_name = self.shorten_namespace(
+            self._namespace_name = ZooCalrissianRunner.shorten_namespace(
                 f"{str(self.zoo_conf.workflow_id).replace('_', '-')}-"
                 f"{uuidString}"
             )


### PR DESCRIPTION
As `shorten_namspace` is a static method, it should be applied to the class (`ZooCalrissianRunner `) rather than an instance of this class (`self`).

This slight modification makes the invocation of the `__init__` method possible from inherited classes.

When this PR is integrated, we can build the Docker image for the ZOO-Project-DRU with the `develop` branch. We now use this one (`feature/access-log-status-failed` branch) to ensure the [eoepca-zoo-wes-runner](https://github.com/cedadev/eoepca-zoo-wes-runner) is working properly.