### PR TITLE
Enable reusing an existing namespace

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,4 +33,5 @@ Calrissian and its runtime context can be customized with:
 
 Per default, pycalrissian create a dedicated namespace per job. To modify this behavior and enable reusing a pre-existing namespace, you can use the following environment variable.
 
-* `USE_NAMESPACE: define the name of the pre-existing namespace that pycalrissian should use for the pods associated with the workflow execution.
+* `USE_NAMESPACE`: define the name of the pre-existing namespace that pycalrissian should use for the pods associated with the workflow execution,
+* `USE_SERVICE_ACCOUNT`: define a specific service account name to use, optional, if not provided value is "default".

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,3 +28,9 @@ Calrissian and its runtime context can be customized with:
 * `DEFAULT_VOLUME_SIZE`: default volume size for the RWX volume used by Calrissian. Expressed in mebibytes (2**20). Defaults to `10000`
 * `DEFAULT_MAX_CORES`: maximum number of cores used by Calrissian pods. Defaults to `2`
 * `DEFAULT_MAX_RAM`: maximum RAM used by Calrissian pods.
+
+### Pre-existing namespace
+
+Per default, pycalrissian create a dedicated namespace per job. To modify this behavior and enable reusing a pre-existing namespace, you can use the following environment variable.
+
+* `USE_NAMESPACE: define the name of the pre-existing namespace that pycalrissian should use for the pods associated with the workflow execution.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "zoo_calrissian_runner"
 dynamic = ["version"]
-description = 'Python library for bridging zoo execution context and calrissian'
+description = 'Python library for bridging ZOO-Project execution context and calrissian'
 readme = "README.md"
 requires-python = ">=3.8"
 license = {text = "Apache License (2.0)"}

--- a/zoo_calrissian_runner/__about__.py
+++ b/zoo_calrissian_runner/__about__.py
@@ -1,1 +1,1 @@
-version = "0.2.1"
+version = "0.3.0"

--- a/zoo_calrissian_runner/__init__.py
+++ b/zoo_calrissian_runner/__init__.py
@@ -17,7 +17,6 @@ from pycalrissian.utils import copy_to_volume
 
 from zoo_calrissian_runner.handlers import ExecutionHandler
 
-
 # useful class for hints in CWL
 @attr.s
 class ResourceRequirement:
@@ -296,13 +295,19 @@ class ZooCalrissianRunner:
         self.handler = execution_handler
 
         self.storage_class = os.environ.get("STORAGE_CLASS", "openebs-nfs-test")
+        self.dedicated_namespace = os.environ.get("USE_NAMESPACE", None)
         self.monitor_interval = 30
         if "lenv" in self.zoo_conf.conf and "usid" in self.zoo_conf.conf["lenv"]:
-            uuidString=self.zoo_conf.conf['lenv']['usid']
-            self._namespace_name = ZooCalrissianRunner.shorten_namespace(
-                f"{str(self.zoo_conf.workflow_id).replace('_', '-')}-"
-                f"{uuidString}"
-            )
+            if self.dedicated_namespace is None:
+                uuidString=self.zoo_conf.conf['lenv']['usid']
+                self._namespace_name = ZooCalrissianRunner.shorten_namespace(
+                    f"{str(self.zoo_conf.workflow_id).replace('_', '-')}-"
+                    f"{uuidString}"
+                )
+            else:
+                self._namespace_name = self.shorten_namespace(
+                    self.dedicated_namespace
+                )
         else:
             self._namespace_name = None
 
@@ -417,12 +422,20 @@ class ZooCalrissianRunner:
 
         logger.info(f"namespace: {namespace}")
 
-        session = CalrissianContext(
-            namespace=namespace,
-            storage_class=self.storage_class,
-            volume_size=self.get_volume_size(),
-            image_pull_secrets=secret_config,
-        )
+        if self.dedicated_namespace is None:
+            session = CalrissianContext(
+                namespace=namespace,
+                storage_class=self.storage_class,
+                volume_size=self.get_volume_size(),
+                image_pull_secrets=secret_config,
+            )
+        else:
+            session = CalrissianContext.from_existing_namespace(
+                namespace=namespace,
+                storage_class=self.storage_class,
+                volume_size=self.get_volume_size(),
+                image_pull_secrets=secret_config,
+            )
         session.initialise()
         self.update_status(progress=15, message="processing environment created, preparing execution")
 

--- a/zoo_calrissian_runner/__init__.py
+++ b/zoo_calrissian_runner/__init__.py
@@ -435,6 +435,7 @@ class ZooCalrissianRunner:
                 storage_class=self.storage_class,
                 volume_size=self.get_volume_size(),
                 image_pull_secrets=secret_config,
+                service_account=os.environ.get("USE_SERVICE_ACCOUNT", None),
             )
         session.initialise()
         self.update_status(progress=15, message="processing environment created, preparing execution")


### PR DESCRIPTION
This PR uses the new `CalrissianContext.from_existing_namespace` class method that enables reusing an existing namespace rather than creating a dedicated namespace for every job.

* Version bump to **0.3.0**
* Use the `CalrissianContext.from_existing_namespace` class method if reusing an existing namespace is required
* Update the documentation to add the new environment variable responsible for defining whether a namespace should be reused or dynamically created per job, and the one for the service account name (optional)
* Minor fix in the package description in pyproject.toml