### PR TITLE
Feature/eoap cwlwrap

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 
 dependencies = [
     "pycalrissian",
-    "cwl-wrapper",
+    "eoap_cwlwrap",
     "cwl-utils>=0.14",
     "attrs",
     "loguru",
@@ -72,7 +72,7 @@ PIP_EXTRA_INDEX_URL = "https://test.pypi.org/simple/"
 skip-install = false
 dependencies = [
     "pycalrissian",
-    "cwl-wrapper",
+    "eoap_cwlwrap",
     "cwl-utils>=0.14",
     "attrs",
     "loguru",
@@ -90,7 +90,7 @@ dependencies = [
     "nose2",
     "coverage",
     "pycalrissian",
-    "cwl-wrapper",
+    "eoap_cwlwrap",
     "cwl-utils>=0.14",
     "attrs",
     "loguru",

--- a/zoo_calrissian_runner/__init__.py
+++ b/zoo_calrissian_runner/__init__.py
@@ -8,15 +8,16 @@ from typing import Union
 import attr
 import cwl_utils
 from eoap_cwlwrap import wrap
+from cwl_loader import dump_cwl
 from cwl_loader import load_cwl_from_location as load_workflow
 from cwl_loader import load_cwl_from_yaml as load_cwl
-from cwl_loader import load_cwl_from_stream
 from loguru import logger
 from pycalrissian.context import CalrissianContext
 from pycalrissian.execution import CalrissianExecution
 from pycalrissian.job import CalrissianJob
 from pycalrissian.utils import copy_to_volume
 import cwl_utils.__meta__ as cwl_meta
+import pathlib
 
 from zoo_calrissian_runner.handlers import ExecutionHandler
 
@@ -232,10 +233,18 @@ class ZooInputs:
         res={}
         hasVal=False;
         for key, value in self.inputs.items():
-            if "dataType" in value:
+            logger.info(f"Processing input {key} with value {value}")
+            if "format" in value:
+                # We can also use res[key]=value
+                # TBD: Should we distinguish between file and basic strings with format, such as date, datetime?
+                # TBD: Should we find the corresponding class from the schema definition?
+                res[key]={
+                    "format": value["format"],
+                    "value": value["value"],
+                }
+            elif "dataType" in value:
                 if isinstance(value["dataType"],list):
                     # How should we pass array for an input?
-                    import json
                     res[key]=value["value"]
                 else:
                     if value["value"]=="NULL":
@@ -250,18 +259,17 @@ class ZooInputs:
                         else:
                             res[key]=value["value"]
             else:
+                # default case
                 if "cache_file" in value:
                     if "mimeType" in value:
                         res[key]={
-                            "class": "File",
-                            "path": value["cache_file"],
-                            "format": value["mimeType"]
+                            "format": value["mimeType"],
+                            "value": value["value"]
                         }
                     else:
                         res[key]={
-                            "class": "File",
-                            "path": value["cache_file"],
-                            "format": "text/plain"
+                            "format": "text/plain",
+                            "value": value["value"]
                         }
                 else:
                     res[key]=value["value"]
@@ -467,13 +475,12 @@ class ZooCalrissianRunner:
         }
 
 
-        self.update_status(progress=20, message="upload required files")
-
+        logger.info(f"Processing parameters: {processing_parameters}")
 
         # Upload input complex data into calrissian_wdir
         for i in processing_parameters:
             if isinstance(processing_parameters[i],dict):
-                if processing_parameters[i]["class"]=="File":
+                if processing_parameters[i].get("class",None)=="File":
                     copy_to_volume(
                         context=session,
                         volume={
@@ -492,9 +499,9 @@ class ZooCalrissianRunner:
                         destination_path="/calrissian",
                     )
                     processing_parameters[i]["path"]=processing_parameters[i]["path"].replace(self.zoo_conf.conf["main"]["tmpPath"],"/calrissian")
-        # checks if all parameters where provided
 
         logger.info("create Calrissian job")
+        self.update_status(progress=21, message="Submit execution")
         job = CalrissianJob(
             cwl=wrapped_workflow,
             params=processing_parameters,
@@ -569,18 +576,14 @@ class ZooCalrissianRunner:
     def wrap(self):
         workflow_id = self.get_workflow_id()
 
+        # Load the directory stage-in CWL
         directory_stage_in_cwl = None
         if os.environ.get("WRAPPER_STAGE_IN", None) is not None:
-            directory_stage_in_cwl = load_workflow(os.environ.get("WRAPPER_STAGE_IN", "/assets/stagein.yaml"))
+            directory_stage_in_cwl = load_workflow(os.environ.get("WRAPPER_STAGE_IN1", "/assets/stagein1.yaml"))
 
+        # Load the directory stage-out CWL
         try:
-            cwl = load_cwl(self.workflow.raw_cwl)
-            logger.info("CWL loaded from raw CWL")
-        except Exception as e:
-            logger.error(f"Cannot load CWL: {e}")
-        try:
-            with open(os.environ.get("WRAPPER_STAGE_OUT", "/assets/stageout.yaml")) as stream:
-                directory_stage_out_cwl = load_cwl_from_stream(stream)
+            directory_stage_out_cwl = load_workflow(os.environ.get("WRAPPER_STAGE_OUT1", "/assets/stageout1.yaml"))
         except Exception as e:
             logger.error(f"Cannot load stage-out CWL: {e}")
             directory_stage_out_cwl = None
@@ -592,6 +595,16 @@ class ZooCalrissianRunner:
                 directory_stage_in=directory_stage_in_cwl,
                 stage_out=directory_stage_out_cwl,
             )
+            with open(os.path.join(
+                 pathlib.Path(self.zoo_conf.conf["main"]["tmpPath"]).absolute(),
+                 f"wrapped-workflow-{self.zoo_conf.conf['lenv']['usid']}.cwl",
+            ),"w") as stream:
+                dump_cwl(wf,stream)
+            logger.info(f"Wrapped workflow saved to {stream.name}")
+            os.environ["ZOO_WRAPPED_WORKFLOW"]=str(os.path.join(
+                 pathlib.Path(self.zoo_conf.conf["main"]["tmpPath"]).absolute(),
+                 f"wrapped-workflow-{self.zoo_conf.conf['lenv']['usid']}.cwl",
+            ))
         except Exception as e:
             logger.error(f"Cannot wrap CWL: {e}")
             raise e

--- a/zoo_calrissian_runner/__init__.py
+++ b/zoo_calrissian_runner/__init__.py
@@ -601,11 +601,14 @@ class ZooCalrissianRunner:
         # Load the directory stage-in CWL
         directory_stage_in_cwl = None
         if os.environ.get("WRAPPER_STAGE_IN", None) is not None:
-            directory_stage_in_cwl = load_workflow(os.environ.get("WRAPPER_STAGE_IN1", "/assets/stagein1.yaml"))
+            directory_stage_in_cwl = load_workflow(os.environ.get("WRAPPER_STAGE_IN", "/assets/stagein.yaml"))
+
+        # Load the directory stage-in CWL
+        file_stage_in_cwl = load_workflow(os.environ.get("WRAPPER_STAGE_IN1", "/assets/stagein-file.yaml"))
 
         # Load the directory stage-out CWL
         try:
-            directory_stage_out_cwl = load_workflow(os.environ.get("WRAPPER_STAGE_OUT1", "/assets/stageout1.yaml"))
+            directory_stage_out_cwl = load_workflow(os.environ.get("WRAPPER_STAGE_OUT", "/assets/stageout.yaml"))
         except Exception as e:
             logger.error(f"Cannot load stage-out CWL: {e}")
             directory_stage_out_cwl = None
@@ -615,6 +618,7 @@ class ZooCalrissianRunner:
                 workflows=self.workflow.cwl,
                 workflow_id=workflow_id,
                 directory_stage_in=directory_stage_in_cwl,
+                file_stage_in=file_stage_in_cwl,
                 stage_out=directory_stage_out_cwl,
             )
             with open(os.path.join(

--- a/zoo_calrissian_runner/__init__.py
+++ b/zoo_calrissian_runner/__init__.py
@@ -570,8 +570,8 @@ class ZooCalrissianRunner:
         workflow_id = self.get_workflow_id()
 
         directory_stage_in_cwl = None
-        if os.environ.get("WRAPPER_STAGE_IN1", None) is not None:
-            directory_stage_in_cwl = load_workflow(os.environ.get("WRAPPER_STAGE_IN1", "/assets/stagein1.yaml"))
+        if os.environ.get("WRAPPER_STAGE_IN", None) is not None:
+            directory_stage_in_cwl = load_workflow(os.environ.get("WRAPPER_STAGE_IN", "/assets/stagein.yaml"))
 
         try:
             cwl = load_cwl(self.workflow.raw_cwl)
@@ -579,7 +579,7 @@ class ZooCalrissianRunner:
         except Exception as e:
             logger.error(f"Cannot load CWL: {e}")
         try:
-            with open(os.environ.get("WRAPPER_STAGE_OUT1", "/assets/stageout1.yaml")) as stream:
+            with open(os.environ.get("WRAPPER_STAGE_OUT", "/assets/stageout.yaml")) as stream:
                 directory_stage_out_cwl = load_cwl_from_stream(stream)
         except Exception as e:
             logger.error(f"Cannot load stage-out CWL: {e}")

--- a/zoo_calrissian_runner/__init__.py
+++ b/zoo_calrissian_runner/__init__.py
@@ -18,6 +18,7 @@ from pycalrissian.job import CalrissianJob
 from pycalrissian.utils import copy_to_volume
 import cwl_utils.__meta__ as cwl_meta
 import pathlib
+import json
 
 from zoo_calrissian_runner.handlers import ExecutionHandler
 
@@ -261,18 +262,39 @@ class ZooInputs:
             else:
                 # default case
                 if "cache_file" in value:
-                    if "mimeType" in value:
+                    if "isArray" in value and value["isArray"]=="true":
+                        res[key]=[]
+                        for i in range(len(value["value"])):
+                            if "mimeType" in value:
+                                res[key].append({
+                                    "format": value["mimeType"][i],
+                                    "value": value["value"][i],
+                                })
+                            else:
+                                res[key].append({
+                                    "format": "text/plain",
+                                    "value": value["value"][i],
+                                })
+                    else:
+                        if "mimeType" in value:
+                            res[key]={
+                                "format": value["mimeType"],
+                                "value": value["value"]
+                            }
+                        else:
+                            res[key]={
+                                "format": "text/plain",
+                                "value": value["value"]
+                            }
+                else:
+                    if "lowerCorner" in value and "upperCorner" in value:
                         res[key]={
-                            "format": value["mimeType"],
-                            "value": value["value"]
+                            "format": "ogc-bbox",
+                            "bbox": json.loads(value["value"]),
+                            "crs": value["crs"].replace("http://www.opengis.net/def/crs/OGC/1.3/","")
                         }
                     else:
-                        res[key]={
-                            "format": "text/plain",
-                            "value": value["value"]
-                        }
-                else:
-                    res[key]=value["value"]
+                        res[key]=value["value"]
         return res 
 
 

--- a/zoo_calrissian_runner/__init__.py
+++ b/zoo_calrissian_runner/__init__.py
@@ -7,8 +7,9 @@ from typing import Union
 
 import attr
 import cwl_utils
+from eoap_cwlwrap import wrap
+from eoap_cwlwrap.loader import load_workflow
 from cwl_utils.parser import load_document_by_yaml
-from cwl_wrapper.parser import Parser
 from loguru import logger
 from pycalrissian.context import CalrissianContext
 from pycalrissian.execution import CalrissianExecution
@@ -569,16 +570,21 @@ class ZooCalrissianRunner:
 
     def wrap(self):
         workflow_id = self.get_workflow_id()
+        workflow_id = self.get_workflow_id()
 
-        wf = Parser(
-            cwl=self.cwl.raw_cwl,
-            output=None,
-            stagein=os.environ.get("WRAPPER_STAGE_IN", "assets/stagein.yaml"),
-            stageout=os.environ.get("WRAPPER_STAGE_OUT", "assets/stageout.yaml"),
-            maincwl=os.environ.get("WRAPPER_MAIN", "assets/maincwl.yaml"),
-            rulez=os.environ.get("WRAPPER_RULES", "assets/rules.yaml"),
-            assets=None,
+        workflows_cwl= load_workflow(self.zoo_conf.conf["lenv"]["workflow_path"])
+
+        directory_stage_in_cwl = None
+        if os.environ.get("WRAPPER_STAGE_IN1", None) is not None:
+            directory_stage_in_cwl = load_workflow(os.environ.get("WRAPPER_STAGE_IN1", "assets/stagein1.yaml"))
+
+        directory_stage_out_cwl = load_workflow(os.environ.get("WRAPPER_STAGE_OUT1", "/assets/stageout1.yaml"))
+
+        wf = wrap(
+            workflows=workflows_cwl,
             workflow_id=workflow_id,
+            directory_stage_in=directory_stage_in_cwl,
+            stage_out=directory_stage_out_cwl,
         )
 
-        return wf.out
+        return wf

--- a/zoo_calrissian_runner/__init__.py
+++ b/zoo_calrissian_runner/__init__.py
@@ -8,8 +8,9 @@ from typing import Union
 import attr
 import cwl_utils
 from eoap_cwlwrap import wrap
-from eoap_cwlwrap.loader import load_workflow
-from cwl_utils.parser import load_document_by_yaml
+from cwl_loader import load_cwl_from_location as load_workflow
+from cwl_loader import load_cwl_from_yaml as load_cwl
+from cwl_loader import load_cwl_from_stream
 from loguru import logger
 from pycalrissian.context import CalrissianContext
 from pycalrissian.execution import CalrissianExecution
@@ -57,10 +58,7 @@ except ImportError:
 class Workflow:
     def __init__(self, cwl, workflow_id):
         self.raw_cwl = cwl
-        if cwl_meta.__version__ < "0.16":
-            self.cwl = load_document_by_yaml(cwl, "io://")
-        else:
-            self.cwl = load_document_by_yaml(cwl, "io://", id_=workflow_id, load_all=True)
+        self.cwl = load_cwl(cwl)
         self.workflow_id = workflow_id
 
     def get_workflow(self) -> cwl_utils.parser.cwl_v1_0.Workflow:
@@ -303,7 +301,7 @@ class ZooCalrissianRunner:
         self.zoo_conf = ZooConf(conf)
         self.inputs = ZooInputs(inputs)
         self.outputs = ZooOutputs(outputs)
-        self.cwl = Workflow(cwl, self.zoo_conf.workflow_id)
+        self.workflow = Workflow(cwl, self.zoo_conf.workflow_id)
 
         self.handler = execution_handler
 
@@ -339,7 +337,7 @@ class ZooCalrissianRunner:
     def get_volume_size(self) -> str:
         """returns volume size that the pods share"""
 
-        resources = self.cwl.eval_resource()
+        resources = self.workflow.eval_resource()
 
         # TODO how to determine the "right" volume size
         volume_size = max(max(resources["tmpdirMin"] or [0]), max(resources["tmpdirMax"] or [0])) + max(
@@ -355,7 +353,7 @@ class ZooCalrissianRunner:
 
     def get_max_cores(self) -> int:
         """returns the maximum number of cores that pods can use"""
-        resources = self.cwl.eval_resource()
+        resources = self.workflow.eval_resource()
 
         max_cores = max(max(resources["coresMin"] or [0]), max(resources["coresMax"] or [0]))
 
@@ -367,7 +365,7 @@ class ZooCalrissianRunner:
 
     def get_max_ram(self) -> str:
         """returns the maximum RAM that pods can use"""
-        resources = self.cwl.eval_resource()
+        resources = self.workflow.eval_resource()
         max_ram = max(max(resources["ramMin"] or [0]), max(resources["ramMax"] or [0]))
 
         if max_ram == 0:
@@ -403,7 +401,7 @@ class ZooCalrissianRunner:
 
     def get_workflow_inputs(self, mandatory=False):
         """Returns the CWL workflow inputs"""
-        return self.cwl.get_workflow_inputs(mandatory=mandatory)
+        return self.workflow.get_workflow_inputs(mandatory=mandatory)
 
     def assert_parameters(self):
         """checks all mandatory processing parameters were provided"""
@@ -570,21 +568,32 @@ class ZooCalrissianRunner:
 
     def wrap(self):
         workflow_id = self.get_workflow_id()
-        workflow_id = self.get_workflow_id()
-
-        workflows_cwl= load_workflow(self.zoo_conf.conf["lenv"]["workflow_path"])
 
         directory_stage_in_cwl = None
         if os.environ.get("WRAPPER_STAGE_IN1", None) is not None:
-            directory_stage_in_cwl = load_workflow(os.environ.get("WRAPPER_STAGE_IN1", "assets/stagein1.yaml"))
+            directory_stage_in_cwl = load_workflow(os.environ.get("WRAPPER_STAGE_IN1", "/assets/stagein1.yaml"))
 
-        directory_stage_out_cwl = load_workflow(os.environ.get("WRAPPER_STAGE_OUT1", "/assets/stageout1.yaml"))
+        try:
+            cwl = load_cwl(self.workflow.raw_cwl)
+            logger.info("CWL loaded from raw CWL")
+        except Exception as e:
+            logger.error(f"Cannot load CWL: {e}")
+        try:
+            with open(os.environ.get("WRAPPER_STAGE_OUT1", "/assets/stageout1.yaml")) as stream:
+                directory_stage_out_cwl = load_cwl_from_stream(stream)
+        except Exception as e:
+            logger.error(f"Cannot load stage-out CWL: {e}")
+            directory_stage_out_cwl = None
 
-        wf = wrap(
-            workflows=workflows_cwl,
-            workflow_id=workflow_id,
-            directory_stage_in=directory_stage_in_cwl,
-            stage_out=directory_stage_out_cwl,
-        )
+        try:
+            wf = wrap(
+                workflows=self.workflow.cwl,
+                workflow_id=workflow_id,
+                directory_stage_in=directory_stage_in_cwl,
+                stage_out=directory_stage_out_cwl,
+            )
+        except Exception as e:
+            logger.error(f"Cannot wrap CWL: {e}")
+            raise e
 
         return wf


### PR DESCRIPTION
With this PR, zoo-calrissian-runner now supports eoap-cwlwrap.

It generates a local file containing the wrapped CWL and sets the `ZOO_WRAPPED_WORKFLOW` environment variable to the file path.

It contains modifications to how data inputs are handled.

Reference: https://github.com/EOEPCA/roadmap/issues/456