### PR TITLE
Feature/eoap cwlwrap

### DIFF
--- a/zoo_calrissian_runner/__init__.py
+++ b/zoo_calrissian_runner/__init__.py
@@ -8,6 +8,7 @@ from typing import Union
 import attr
 import cwl_utils
 from eoap_cwlwrap import wrap
+#from eoap_cwlwrap import wrap_locations
 from cwl_loader import dump_cwl
 from cwl_loader import load_cwl_from_location as load_workflow
 from cwl_loader import load_cwl_from_yaml as load_cwl
@@ -20,7 +21,8 @@ from pycalrissian.utils import copy_to_volume
 import cwl_utils.__meta__ as cwl_meta
 import pathlib
 import json
-
+import yaml
+from io import StringIO
 from zoo_calrissian_runner.handlers import ExecutionHandler
 
 # useful class for hints in CWL
@@ -615,17 +617,20 @@ class ZooCalrissianRunner:
             directory_stage_out_cwl = None
 
         try:
-            wrapped_worflow = wrap(
+            wrapped_workflow = wrap(
                 workflows=self.workflow.cwl,
                 workflow_id=workflow_id,
                 directory_stage_in=directory_stage_in_cwl,
                 file_stage_in=file_stage_in_cwl,
                 stage_out=directory_stage_out_cwl,
             )
-            wf = save(
-                val=wrapped_worflow,
-                relative_uris=False
+            # TODO: this is a workaround, remove it as soon as a better solution is available
+            buffer = StringIO()
+            dump_cwl(
+                process=wrapped_workflow,
+                stream=buffer
             )
+            wf = yaml.safe_load(buffer.getvalue())
         except Exception as e:
             logger.error(f"Cannot wrap CWL: {e}")
             raise e

--- a/zoo_calrissian_runner/__init__.py
+++ b/zoo_calrissian_runner/__init__.py
@@ -11,6 +11,7 @@ from eoap_cwlwrap import wrap
 from cwl_loader import dump_cwl
 from cwl_loader import load_cwl_from_location as load_workflow
 from cwl_loader import load_cwl_from_yaml as load_cwl
+from cwl_utils.parser import save
 from loguru import logger
 from pycalrissian.context import CalrissianContext
 from pycalrissian.execution import CalrissianExecution
@@ -614,23 +615,17 @@ class ZooCalrissianRunner:
             directory_stage_out_cwl = None
 
         try:
-            wf = wrap(
+            wrapped_worflow = wrap(
                 workflows=self.workflow.cwl,
                 workflow_id=workflow_id,
                 directory_stage_in=directory_stage_in_cwl,
                 file_stage_in=file_stage_in_cwl,
                 stage_out=directory_stage_out_cwl,
             )
-            with open(os.path.join(
-                 pathlib.Path(self.zoo_conf.conf["main"]["tmpPath"]).absolute(),
-                 f"wrapped-workflow-{self.zoo_conf.conf['lenv']['usid']}.cwl",
-            ),"w") as stream:
-                dump_cwl(wf,stream)
-            logger.info(f"Wrapped workflow saved to {stream.name}")
-            os.environ["ZOO_WRAPPED_WORKFLOW"]=str(os.path.join(
-                 pathlib.Path(self.zoo_conf.conf["main"]["tmpPath"]).absolute(),
-                 f"wrapped-workflow-{self.zoo_conf.conf['lenv']['usid']}.cwl",
-            ))
+            wf = save(
+                val=wrapped_worflow,
+                relative_uris=False
+            )
         except Exception as e:
             logger.error(f"Cannot wrap CWL: {e}")
             raise e


### PR DESCRIPTION
With this PR, zoo-calrissian-runner supports eoap-cwlwrap and does not require any modification in pycalrissian. So, it makes this PR obsolete: https://github.com/Terradue/pycalrissian/pull/21.

Reference: https://github.com/EOEPCA/roadmap/issues/456