### PR TITLE
Add load_a_workflow method to ZooCalrissianRunner

### DIFF
--- a/tests/test_zoo_conf.py
+++ b/tests/test_zoo_conf.py
@@ -2,6 +2,7 @@ import tempfile
 import unittest
 
 import yaml
+import os
 from cwl_utils.parser.cwl_v1_0 import Workflow
 
 from zoo_calrissian_runner import ZooCalrissianRunner
@@ -95,6 +96,9 @@ class TestCalrissianContext(unittest.TestCase):
         inputs["param_2"] = {"value": "value2"}
         outputs = {"Result": {"value": ""}}
         runner = ZooCalrissianRunner(cwl=self.cwl, conf=self.conf, inputs=inputs, outputs=outputs)
+
+        base_url = 'https://raw.githubusercontent.com/eoap/application-package-patterns/refs/heads/main'
+        os.environ["WRAPPER_STAGE_OUT"] = f"{base_url}/templates/stage-out.cwl"
 
         wrapped = runner.wrap()
 

--- a/zoo_calrissian_runner/__init__.py
+++ b/zoo_calrissian_runner/__init__.py
@@ -598,23 +598,31 @@ class ZooCalrissianRunner:
 
         return exit_value
 
+    def load_a_workflow(self, location):
+        try:
+            workflow = load_workflow(location)
+        except Exception as e:
+            logger.error(f"Cannot load CWL from {location}: {e}")
+            workflow = None
+        return workflow
+
     def wrap(self):
         workflow_id = self.get_workflow_id()
 
         # Load the directory stage-in CWL
-        directory_stage_in_cwl = None
-        if os.environ.get("WRAPPER_STAGE_IN", None) is not None:
-            directory_stage_in_cwl = load_workflow(os.environ.get("WRAPPER_STAGE_IN", "/assets/stagein.yaml"))
+        directory_stage_in_cwl = self.load_a_workflow(
+            os.environ.get("WRAPPER_STAGE_IN", "/assets/stagein.yaml")
+        )
 
         # Load the directory stage-in CWL
-        file_stage_in_cwl = load_workflow(os.environ.get("WRAPPER_STAGE_IN_FILE", "/assets/stagein-file.yaml"))
+        file_stage_in_cwl = self.load_a_workflow(
+            os.environ.get("WRAPPER_STAGE_IN_FILE", "/assets/stagein-file.yaml")
+        )
 
         # Load the directory stage-out CWL
-        try:
-            directory_stage_out_cwl = load_workflow(os.environ.get("WRAPPER_STAGE_OUT", "/assets/stageout.yaml"))
-        except Exception as e:
-            logger.error(f"Cannot load stage-out CWL: {e}")
-            directory_stage_out_cwl = None
+        directory_stage_out_cwl = self.load_a_workflow(
+            os.environ.get("WRAPPER_STAGE_OUT", "/assets/stageout.yaml")
+        )
 
         try:
             wrapped_workflow = wrap(


### PR DESCRIPTION
The `load_a_workflow` method is used for the `directory_stage_in`, `file_stage_in` and `stage_out` parameters from the [wrap](https://eoepca.github.io/eoap-cwlwrap/api/latest/eoap_cwlwrap/#wrap) operation provided by [eoap_cwlwrap](https://pypi.org/project/eoap-cwlwrap/).

Update test_conf_zoo to use the stageout from the eoap/application-package-patterns repository to test the wrap operation