### PR TITLE
Update to support array of literal data inputs

### DIFF
--- a/zoo_calrissian_runner/__init__.py
+++ b/zoo_calrissian_runner/__init__.py
@@ -236,9 +236,10 @@ class ZooInputs:
         """Returns a list with the input parameters keys"""
         res={}
         hasVal=False;
+        allowed_types = ["int","float","boolean","double"]
         for key, value in self.inputs.items():
             logger.info(f"Processing input {key} with value {value}")
-            if "format" in value:
+            if "format" in value and not("dataType" in value and value["dataType"] in allowed_types):
                 # We can also use res[key]=value
                 # TBD: Should we find the corresponding class from the schema definition?
                 res[key]={
@@ -248,7 +249,15 @@ class ZooInputs:
             elif "dataType" in value:
                 if isinstance(value["dataType"],list):
                     # How should we pass array for an input?
-                    res[key]=value["value"]
+                    if value["dataType"][0] in allowed_types:
+                        if value["dataType"][0] in ["double","float"]:
+                            res[key]=[float(item) for item in value["value"]]
+                        elif value["dataType"][0] == "integer":
+                            res[key]=[int(item) for item in value["value"]]
+                        elif value["dataType"][0] == "boolean":
+                            res[key]=[bool(item) for item in value["value"]]
+                    else:
+                        res[key]=value["value"]
                 else:
                     if value["value"]=="NULL":
                         res[key]=None


### PR DESCRIPTION
This pull request refines how input parameters are processed in the `get_processing_parameters` method of `zoo_calrissian_runner/__init__.py`. It improves handling different data types, especially for array inputs, ensuring that values are cast adequately to their intended types.

* Introduced an `allowed_types` list to explicitly define which data types should be specially handled (`int`, `float`, `boolean`, `double`) and used this to control when to process the `format` field.
* Enhanced array input handling by casting elements to the correct type (`float`, `int`, or `bool`) based on the first element of the `dataType` array, ensuring data consistency for numeric and boolean types.
